### PR TITLE
Implement the Thread-Safe Queue

### DIFF
--- a/blocking_queue/.idea/.gitignore
+++ b/blocking_queue/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/blocking_queue/.idea/blocking_queue.iml
+++ b/blocking_queue/.idea/blocking_queue.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/blocking_queue/.idea/misc.xml
+++ b/blocking_queue/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/blocking_queue/.idea/modules.xml
+++ b/blocking_queue/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/blocking_queue.iml" filepath="$PROJECT_DIR$/.idea/blocking_queue.iml" />
+    </modules>
+  </component>
+</project>

--- a/blocking_queue/.idea/vcs.xml
+++ b/blocking_queue/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/blocking_queue/blocking_queue.hpp
+++ b/blocking_queue/blocking_queue.hpp
@@ -1,0 +1,54 @@
+//
+// Created by HANYOUNG PARK on 4/11/21.
+//
+
+#ifndef BLOCKING_QUEUE_BLOCKING_QUEUE_HPP
+#define BLOCKING_QUEUE_BLOCKING_QUEUE_HPP
+
+#include <queue>
+#include <boost/thread.hpp>
+
+/**
+ * Thread-Safe Queue
+ * Don't mix use between [front, pop] and [poll]. Even it's not crushed,
+ * it can't be guaranteed that the front is correct.
+ * @tparam T
+ */
+template<typename T>
+class blocking_queue {
+public:
+    [[nodiscard]] bool empty() const {
+        return q.empty();
+    }
+
+    void push(T val) {
+        mutex.lock();
+        q.push(val);
+        mutex.unlock();
+    }
+
+    void pop() {
+        mutex.lock();
+        q.pop();
+        mutex.unlock();
+    }
+
+    T front() const {
+        return q.front();
+    }
+
+    T poll() {
+        mutex.lock();
+        T ret = q.front();
+        q.pop();
+        mutex.unlock();
+        return ret;
+    }
+
+private:
+    std::queue<T> q;
+    boost::mutex mutex;
+};
+
+
+#endif //BLOCKING_QUEUE_BLOCKING_QUEUE_HPP


### PR DESCRIPTION
The blocking queue the thread-safe queue is using the queue of STL container and the mutax of Boost.
The mutax lock only when the queue is update. So, for the read-only operation like empty, front isn't locked.